### PR TITLE
Add use std::arch::aarch64::*; to simd.rs to compile on Mac M1 with simd feature enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,10 @@ mod node16;
 mod node256;
 mod node4;
 mod node48;
+
+#[cfg(feature = "simd")]
 mod simd;
+
 pub use art::Art;
 
 /// A trait some constraints on the key of art.

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -1,5 +1,8 @@
+#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+use std::arch::aarch64::*;
+
+
 #[inline]
-#[cfg(feature = "simd")]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
 pub(crate) unsafe fn _mm_movemask_epi8(input: uint8x16_t) -> i32 {
     // Example input (half scale):


### PR DESCRIPTION
There are 11 compile errors on master when building on a Mac m1 with simd feature enabled.

This is fixed by adding 

```
#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
use std::arch::aarch64::*;
```

to simd.rs.

All tests pass 

```
cargo test -F simd
```

Please let me know if you need anything else in order to merge this PR.